### PR TITLE
fix: delete migrate adds_image_to_users

### DIFF
--- a/db/migrate/20240325041734_adds_image_to_users.rb
+++ b/db/migrate/20240325041734_adds_image_to_users.rb
@@ -1,5 +1,0 @@
-class AddsImageToUsers < ActiveRecord::Migration[7.0]
-  def change
-    add_column :users, :image, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,10 +120,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_14_051614) do
     t.string "name"
     t.text "description"
     t.float "value"
-    t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "event_id", null: false
+    t.string "image"
     t.index ["event_id"], name: "index_type_tickets_on_event_id"
   end
 


### PR DESCRIPTION
## Motivação

Ao rodar as migrações da aplicação está ocorrendo um erro na migrate: `adds_image_to_users`. Estressando um pouco o assunto, está ocorrendo mais especificamnete na tentativa  de criar uma coluna imagem da tabela **users** que já existe.

![Screenshot from 2024-08-17 22-30-07](https://github.com/user-attachments/assets/9e1b4de0-5b93-4bf1-9af6-f986e3b342a0)

## Proposta de solução

Proponho deletar essa migração, visto que a única função dela é tentar criar uma coluna que já existe no momento de rodar a migração em questão.

## Testes
Evidência da execução completa das migrações pós correção:

![2024-08-21_01-14](https://github.com/user-attachments/assets/567deecb-2969-461f-9363-c74b7b3ae548)

## Links Importante

- Trello: [Corrigir duplicata de coluna name 'image'](https://trello.com/c/bLNT3qTH/43-corrigir-duplicata-de-coluna-name-image)
