### PR TITLE
Omniauth.rb comentado

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
+=begin
 Rails.application.config.middleware.use OmniAuth::Builder do
     provider :google_oauth2, Rails.application.credentials.google[:client_id_key], Rails.application.credentials.google[:secret_client_key], scope: 'email, profile'
 end
 
 OmniAuth.config.allowed_request_methods = %i[get]
+=end


### PR DESCRIPTION
## Motivação

Precisamos fazer essa mudança para poder liberar o deploy da aplicação de forma rápida e fácil, uma vez que as credenciais do Google requisitadas no arquivo omniauth.rb estão causando a falha do deploy no Railway.

## Proposta de solução

Propomos a seguinte solução: Comentar o arquivo inteiro para que o erro seja suprimido momentaneamente. No futuro será feito um fix definitivo.